### PR TITLE
chore(): Build and release arm64 image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,7 @@ target "build" {
     context = "./"
     dockerfile = "Dockerfile"
     platforms = [
-        "linux/amd64"
+        "linux/amd64",
+        "linux/arm64"
     ]
 }


### PR DESCRIPTION
As the title says. Hoping this change builds and releases an additional image with the arm64 arch.

Also adding workflow dispatch to the `docker-release.yml` for a better testing experience (if this is bad I'll remove it).