### PR TITLE
fix(): support multi-arch builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,6 +58,7 @@ jobs:
           load: true
           no-cache: true
           targets: build
+          provenance: false
 
       - name: Run Trivy to check Docker images for vulnerabilities
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,7 +55,7 @@ jobs:
             ./docker-bake.hcl
             ${{ steps.metadata.outputs.bake-file }}
           push: true
-          load: true
+          load: false
           no-cache: true
           targets: build
           provenance: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,7 +2,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -47,6 +46,6 @@ jobs:
                     ./docker-bake.hcl
                     ${{ steps.metadata.outputs.bake-file }}
                 push: true
-                load: true
                 no-cache: true
                 targets: build
+                provenance: false


### PR DESCRIPTION
This PR adds:
 - set `load = false` (default) in docker-bake action
 - set `provenance=false` in docker-bake action

Should allow multi-arch builds with these changes