### PR TITLE
chore: update CODEOWNERS team ref to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # @rewindio/codeowners will be requested for review when someone
 # opens a pull request.
 
-*       @rewindio/devops
+*       @rewind-community/devops


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community` as part of the OSS-repo classification cleanup (terraform side: rewindio/terraform-rewindio-github#370). The existing `@rewindio/devops` reference is silently dropped by GitHub because team references can't cross organizations — swapping to `@rewind-community/devops` restores reviewer assignment.

## Related PRs

- rewindio/terraform-rewindio-github#370 (TF move)

## Testing Performed

Single-line CODEOWNERS update — no code paths affected.

[DEVOPS-4349]: https://rewind.atlassian.net/browse/DEVOPS-4349