### PR TITLE
chore(DEVOPS-4349): update popular-tool refs from rewindio to rewind-community

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -23,7 +23,7 @@ jobs:
   languages:
     runs-on: ubuntu-latest
     steps:
-      - uses: rewindio/list-repository-languages@main
+      - uses: rewind-community/list-repository-languages@921d2698f59f788c9ff7c77f2400ffad97b7b5e1 # main
         id: list-languages
         with:
           codeql: 'true'


### PR DESCRIPTION
# **JIRA Issue:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Related PRs

- rewindio/terraform-rewindio-github#368

## Description of change

`auto-assign-reviewer-by-issuer` and `list-repository-languages` moved from `rewindio` to `rewind-community` as part of the OSS-repo classification cleanup. This PR updates this repo's workflow references to point at the new home. GitHub URL redirects keep the old refs working today, but the explicit reference is now accurate and the cross-org redirect dependency is gone.

## Testing Performed

Mechanical org-prefix swap in `uses:` lines and any other reference shape — no behavioral change. Action runs identically.
