### PR TITLE
fix(): tag docker images with commit sha

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.TIMESTAMP_TAG }}
+            type=raw,value=${{ github.sha }}
 
       - name: Build for development
         uses: docker/bake-action@a66e1c87e2eca0503c343edf1d208c716d54b8a8 # v7.1.0


### PR DESCRIPTION
## Why
- Built images were only tagged with a build timestamp, making it hard to trace an image back to an exact commit.

## How
- Added a `type=raw,value=${{ github.sha }}` tag to the `docker/metadata-action` step in `docker-build.yml`, so the `build` bake target (which inherits its tags) now publishes both the timestamp and commit-SHA tags.

## Testing Performed
- CI-config only change; no tests run. Validated tag expansion produces correctly registry/owner-prefixed refs (`ghcr.io/<owner>/<repo>:<sha>`).