### PR TITLE
feat: emit v{major} and v{major}.{minor} docker tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}},value=${{steps.semantic_release.outputs.new_release_version}}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{steps.semantic_release.outputs.new_release_version}}
+            type=semver,pattern=v{{major}},value=${{steps.semantic_release.outputs.new_release_version}}
 
       - name: Build for development
         if: steps.semantic_release.outputs.new_release_published == 'true'


### PR DESCRIPTION
## Why

Consumers (`rewindio/github-action-serverless`, etc.) currently have to pin this image by full semver tag or sha256 digest, which means every notifier release requires a follow-up PR in every consumer to roll forward. Ratchet-style digest pinning protected against supply-chain swaps but added per-release toil for an image we own end-to-end.

Switching to floating major/minor tags lets consumers pin `:v1` and pick up patches and minors automatically — same pattern GitHub Actions itself uses (`actions/checkout@v4`).

## What

Adds two extra patterns to `docker/metadata-action`:
- `v{major}` (e.g. `v1`)
- `v{major}.{minor}` (e.g. `v1.1`)

`docker/metadata-action` overwrites these on each release, so they always float to the newest image. The existing `{{version}}` tag (e.g. `1.1.10`) is preserved unchanged for callers that still want an exact pin.

## Linked

- DEVOPS-6081
- Consumer PR: rewindio/github-action-serverless#TBD (must merge **after** this release fires)