### PR TITLE
ci(): use GitHub App token for semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Create GitHub access token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.TAGGER_APP_ID }}
+          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Semantic Release
         id: semantic_release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Docker Buildx
         if: steps.semantic_release.outputs.new_release_published == 'true'


### PR DESCRIPTION
## Why
- The default `GITHUB_TOKEN` lacks the permissions needed to push release tags/commits.

## How
- Add `actions/create-github-app-token` step to mint a token from the Tagger GitHub App (`TAGGER_APP_ID` / `TAGGER_PRIVATE_KEY`).
- Pass the app token to the semantic-release action instead of `GITHUB_TOKEN`.

## Testing Performed
- Ran `poetry run pytest` — 24 passed.